### PR TITLE
Remove Handler Properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 os: osx
-osx_image: xcode10
+osx_image: xcode11
 sudo: false
 language: objective-c
 
 env:
-  - SDK="iphoneos12.0"
+  - SDK="iphoneos13.0"
 
 script:
   - xcodebuild clean build -sdk $SDK -configuration Debug CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO

--- a/Example/Example/ObjCWebViewController.m
+++ b/Example/Example/ObjCWebViewController.m
@@ -32,11 +32,7 @@
     self.webView = [[WKCookieWebView alloc] initWithFrame:CGRectZero configurationBlock:^(WKWebViewConfiguration * _Nonnull configuration) {
         
     }];
-    [self.webView setOnDecidePolicyForNavigationAction:^(WKWebView * _Nonnull webView,
-                                                         WKNavigationAction * _Nonnull navigationAction,
-                                                         void (^ _Nonnull decisionHandler)(WKNavigationActionPolicy)) {
-        decisionHandler(WKNavigationActionPolicyAllow);
-    }];
+    
     [self.webView setOnUpdateCookieStorage:^(WKCookieWebView * _Nonnull webView) {
     }];
     

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -39,8 +39,6 @@ class ViewController: UIViewController {
             setupWebView()
             webView.load(URLRequest(url: URL(string: urlString)!))
         }
-        
-//        perform(#selector(printCookie), with: nil, afterDelay: 1.0)
     }
     
     // MARK: - Private
@@ -59,14 +57,6 @@ class ViewController: UIViewController {
             options: [],
             metrics: nil,
             views: views))
-        
-        webView.onDecidePolicyForNavigationAction = { (webView, navigationAction, decisionHandler) in
-            decisionHandler(.allow)
-        }
-        
-        webView.onDecidePolicyForNavigationResponse = { (webView, navigationResponse, decisionHandler) in
-            decisionHandler(.allow)
-        }
         
         webView.onUpdateCookieStorage = { [weak self] (webView) in
             self?.printCookie()
@@ -87,6 +77,16 @@ class ViewController: UIViewController {
 }
 
 extension ViewController: WKNavigationDelegate {
+    
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        print("ViewController.decidePolicyFor.Action")
+        decisionHandler(.allow)
+    }
+    
+    func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
+        print("ViewController.decidePolicyFor.Response")
+        decisionHandler(.allow)
+    }
     
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         print("didFail.error : \(error)")


### PR DESCRIPTION
WKNavigationDelegate function instead of properties

## Remove Handler Properties

```swift
// @available(iOS 8.0, *)
// optional public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Swift.Void)
public var onDecidePolicyForNavigationAction: ((WKWebView, WKNavigationAction, @escaping (WKNavigationActionPolicy) -> Swift.Void) -> Void)?

// @available(iOS 8.0, *)
// optional public func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Swift.Void)
public var onDecidePolicyForNavigationResponse: ((WKWebView, WKNavigationResponse, @escaping (WKNavigationResponsePolicy) -> Swift.Void) -> Void)?

// @available(iOS 8.0, *)
// optional public func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Swift.Void)
public var onDidReceiveChallenge: ((WKWebView, URLAuthenticationChallenge, @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Swift.Void) -> Void)?
```